### PR TITLE
✨ feat: 엑셀 파싱 후 DB 저장

### DIFF
--- a/9th-BE-Networking-1/src/main/java/com/cotato/networking1/Networking1Application.java
+++ b/9th-BE-Networking-1/src/main/java/com/cotato/networking1/Networking1Application.java
@@ -1,0 +1,13 @@
+package com.cotato.networking1;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+@RequiredArgsConstructor
+public class Networking1Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Networking1Application.class, args);
+    }
+}

--- a/9th-BE-Networking-1/src/main/java/com/cotato/networking1/controller/PropertyController.java
+++ b/9th-BE-Networking-1/src/main/java/com/cotato/networking1/controller/PropertyController.java
@@ -1,0 +1,31 @@
+package com.cotato.networking1.controller;
+
+import com.cotato.networking1.domain.Property;
+import com.cotato.networking1.service.PropertyService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+@AllArgsConstructor
+public class PropertyController {
+    private PropertyService propertyService;
+
+    @PostMapping("/test-data")
+    public ResponseEntity<?> uploadPropertiesData(@RequestParam("file")MultipartFile file){
+        propertyService.savePropertiesToDatabase(file);
+        return ResponseEntity
+                .ok(Map.of("Message", "Properties data uploaded and saved to database successfully"));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<Property>> getProperties(){
+        return new ResponseEntity<>(propertyService.getProperties(), HttpStatus.FOUND);
+    }
+}

--- a/9th-BE-Networking-1/src/main/java/com/cotato/networking1/domain/Property.java
+++ b/9th-BE-Networking-1/src/main/java/com/cotato/networking1/domain/Property.java
@@ -1,0 +1,25 @@
+package com.cotato.networking1.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Property {
+    @Id
+    @Column(name = "property_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "zip_code")
+    private String zipCode;
+
+    @Column(name = "road_address")
+    private String roadAddress;
+
+    @Column(name = "lot_number_address")
+    private String lotNumberAddress;
+}

--- a/9th-BE-Networking-1/src/main/java/com/cotato/networking1/repository/PropertyRepository.java
+++ b/9th-BE-Networking-1/src/main/java/com/cotato/networking1/repository/PropertyRepository.java
@@ -1,0 +1,9 @@
+package com.cotato.networking1.repository;
+
+import com.cotato.networking1.domain.Property;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PropertyRepository extends JpaRepository<Property, Long> {
+}

--- a/9th-BE-Networking-1/src/main/java/com/cotato/networking1/service/ExcelUploadService.java
+++ b/9th-BE-Networking-1/src/main/java/com/cotato/networking1/service/ExcelUploadService.java
@@ -1,0 +1,127 @@
+package com.cotato.networking1.service;
+
+import com.cotato.networking1.domain.Property;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+public class ExcelUploadService {
+
+    // 업로드된 파일이 유효한 엑셀 파일인지 확인
+    public static boolean isValidExcelFile(MultipartFile file){
+        return Objects.equals(file.getContentType(), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+    }
+
+    // 엑셀 파일에서 속성 데이터 읽어오기
+    public static List<Property> getPropertiesDataFromExcel(InputStream inputStream){
+        List<Property> properties = new ArrayList<>();
+
+        XSSFWorkbook workbook = null;
+
+        try {
+            // 엑셀파일 읽어오기
+            workbook = new XSSFWorkbook(inputStream);
+            // sheet 이름
+            XSSFSheet sheet = workbook.getSheet("Sheet1");
+
+
+            int rowIndex = 0;
+            for (Row row : sheet){
+                // 헤더행 처리
+                if (rowIndex == 0){
+                    rowIndex++;
+                    continue;
+                }
+
+                Iterator<Cell> cellIterator = row.iterator();
+                Property.PropertyBuilder propertyBuilder = Property.builder();
+
+                StringBuilder roadAddressBuilder = new StringBuilder();
+                StringBuilder lotNumberAddressBuilder = new StringBuilder();
+                while (cellIterator.hasNext()){
+                    Cell cell = cellIterator.next();
+                    switch (cell.getColumnIndex()){
+                        case 0:
+                            propertyBuilder.zipCode(cellToString(cell));
+                            break;
+                        case 1:
+                            propertyBuilder.roadAddress(cellToString(cell));
+                            roadAddressBuilder.append(cellToString(cell));
+                            propertyBuilder.lotNumberAddress(cellToString(cell));
+                            lotNumberAddressBuilder.append(cellToString(cell));
+                            break;
+                        case 2:
+                            roadAddressBuilder.append(" ").append(cellToString(cell));
+                            lotNumberAddressBuilder.append(" ").append(cellToString(cell));
+                            break;
+                        case 3:
+                            roadAddressBuilder.append(" ").append(cellToString(cell));
+                            break;
+                        case 4:
+                            roadAddressBuilder.append(" ").append(cellToString(cell));
+                            break;
+                        case 5:
+                            roadAddressBuilder.append(cellToString(cell));
+                            break;
+                        case 6:
+                            lotNumberAddressBuilder.append(" ").append(cellToString(cell));
+                            break;
+                        case 7:
+                            lotNumberAddressBuilder.append(" ").append(cellToString(cell));
+                            break;
+                        case 8:
+                            lotNumberAddressBuilder.append("-").append(cellToString(cell));
+                            break;
+                        default:
+                            break;
+                    }
+                }
+
+                Property property = propertyBuilder
+                        .lotNumberAddress(lotNumberAddressBuilder.toString())
+                        .roadAddress(roadAddressBuilder.toString())
+                        .build();
+                properties.add(property);
+
+
+            }
+        } catch (IOException e){
+            e.getStackTrace();
+        }
+
+        return properties;
+    }
+
+    // 다른 형식의 셀 값을 문자열로 변환
+    private static String cellToString(Cell cell) {
+        if (cell == null) {
+            return "";
+        }
+
+        switch (cell.getCellType()) {
+            case NUMERIC:
+                return String.valueOf(cell.getNumericCellValue()).replace(".0", "");
+            case STRING:
+                return cell.getStringCellValue();
+            case BOOLEAN:
+                return String.valueOf(cell.getBooleanCellValue());
+            case FORMULA:
+                return cell.getCellFormula();
+            case BLANK:
+                return "";
+            default:
+                return "";
+        }
+    }
+
+
+}

--- a/9th-BE-Networking-1/src/main/java/com/cotato/networking1/service/PropertyService.java
+++ b/9th-BE-Networking-1/src/main/java/com/cotato/networking1/service/PropertyService.java
@@ -1,0 +1,30 @@
+package com.cotato.networking1.service;
+
+import com.cotato.networking1.domain.Property;
+import com.cotato.networking1.repository.PropertyRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public class PropertyService {
+    private PropertyRepository propertyRepository;
+
+    public void savePropertiesToDatabase(MultipartFile file){
+        if(ExcelUploadService.isValidExcelFile(file)){
+            try {
+                List<Property> properties = ExcelUploadService.getPropertiesDataFromExcel(file.getInputStream());
+                this.propertyRepository.saveAll(properties);
+            } catch (IOException e){
+                throw new IllegalArgumentException("The file is not a valid excel file");
+            }
+        }
+    }
+    public List<Property> getProperties(){
+        return propertyRepository.findAll();
+    }
+}


### PR DESCRIPTION
## **⛅ 작업내용**
- [x] 엑셀 파싱 후 DB 저장


## **🐛 FIX**
Cannot get a STRING value from a NUMERIC cell
-> 다른 형식의 셀 값을 문자열로 변환해서 해결해줬다.

## **👀 스크린샷**
<img width="1025" alt="스크린샷 2024-03-26 오후 7 54 05" src="https://github.com/nar0ng/9th-BE-Networking-1/assets/71819594/06740002-078b-4d82-80a6-0014c4664cdd">
<img width="816" alt="스크린샷 2024-03-26 오후 7 54 19" src="https://github.com/nar0ng/9th-BE-Networking-1/assets/71819594/66180106-6b42-4fec-add1-e6add6341f5b">

##  **🔥 TIL**
이번 네트워킹 과제에서 엑셀 파일을 파싱하여 db에 저장하는 것을 해봤는데 POI 라이브러리 사용했다. 처음 해본 거여서 정리 해봤다! 

### POI
공식사이트: http://poi.apache.org/download.html.
아파치 소프트웨어 재단에서 만든 라이브러리로 마이크로소프트 오피스 파일을 자바 언어로 읽고 쓰는 기능을 제공한다.

4가지 요소만 기억하자. 
1. Workbook
하나의 엑셀 파일을 의미
2. Sheet 
엑셀파일의 시트를 의미
3. Row
행
4. Cell
열

**의존성 추가**
```
 // poi
    implementation group: 'org.apache.poi', name: 'poi', version: '4.1.2'
    implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '4.1.2'
}
``` 
### **엑셀 파일 읽기**
1. 이미 있는 엑셀 파일을 사용해서 workbook 인스턴스를 생성한다.
2. 해당 workbook에서 원하는 sheet를 가져온다.
3. sheet내에서 읽고자 하는 행 번호를 지정한다.
4. row에 있는 모든 cell을 순회하면서 읽는다.
5. 3과 4의 과정을 sheet 내의 모든 행을 읽을 때까지 반복한다.


참고자료:
 https://dailylifecoding.tistory.com/entry/apache-POI-간단-사용법-1
https://www.youtube.com/watch?v=3VNdnz9pqak
